### PR TITLE
[177346544]:Fix Remove 0 content size urls from list of valid urls

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FindSiteIcon.MixProject do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @url "https://github.com/XukuLLC/find_site_icon"
   @maintainers [
     "Neil Berkman"


### PR DESCRIPTION
We have added a filter for image urls which return content-length header as 0.

If we find that some websites are sending 0 as content-length but with valid images, we'll have to add them to a naughty list and let them through.