### PR TITLE
177334117 ignore non url values

### DIFF
--- a/lib/find_site_icon.ex
+++ b/lib/find_site_icon.ex
@@ -79,6 +79,7 @@ defmodule FindSiteIcon do
     # If there is any error with parsing, link_tags will handle it by returning an empty array
     |> link_tags()
     |> link_tags_to_urls()
+    |> filter_base64_encoded_images()
     |> merge_known_icon_locations()
     |> relative_to_absolute_urls(url)
     |> fetch_icons()
@@ -158,6 +159,14 @@ defmodule FindSiteIcon do
     Enum.filter(icon_infos, fn
       %IconInfo{size: size} when is_integer(size) and size > 0 -> true
       _ -> false
+    end)
+  end
+
+  defp filter_base64_encoded_images(urls) when is_list(urls) do
+    # Remove encoded images, which is done sometimes instead of providing an actual image
+    Enum.filter(urls, fn
+      "data:" <> _ -> false
+      _ -> true
     end)
   end
 

--- a/lib/find_site_icon.ex
+++ b/lib/find_site_icon.ex
@@ -157,7 +157,7 @@ defmodule FindSiteIcon do
   defp filter_empty_icons(icon_infos) when is_list(icon_infos) do
     # We'll remove icon infos with size == 0 here
     Enum.filter(icon_infos, fn
-      %IconInfo{size: size} when is_integer(size) and size > 0 -> true
+      %IconInfo{size: size} when (is_integer(size) and size > 0) or is_nil(size) -> true
       _ -> false
     end)
   end

--- a/lib/find_site_icon/utils/icon_utils.ex
+++ b/lib/find_site_icon/utils/icon_utils.ex
@@ -58,5 +58,5 @@ defmodule FindSiteIcon.Util.IconUtils do
     end
   end
 
-  def generate_size(_), do: 0
+  def generate_size(_), do: nil
 end

--- a/test/find_site_icon_test.exs
+++ b/test/find_site_icon_test.exs
@@ -20,6 +20,26 @@ defmodule FindSiteIconTest do
     end
   end
 
+  test "A bunch of common and peculiar websites, we should be able to fetch their icons" do
+    websites = [
+      "https://www.washingtonpost.com/",
+      "https://www.wsj.com/",
+      "https://www.thedailybeast.com/",
+      "https://thehustle.co/",
+      "http://paulgraham.com/earnest.html",
+      "https://www.thehindu.com/"
+    ]
+
+    websites
+    |> Task.async_stream(fn url -> FindSiteIcon.find_icon(url) end, on_timeout: :kill_task)
+    |> Enum.each(fn
+      {:ok, _} -> assert true
+      # We currently ignore timeouts. These tests are only for peace of mind.
+      {:exit, :timeout} -> assert true
+      _ -> assert false, "Failed to fetch an icon"
+    end)
+  end
+
   describe "finds the site icon when cache is empty" do
     test "link tags present and hold largest icon in favicon" do
       icon_relative_url = "/favicon-1920831098fa0df09sdf8a09sd8f.ico"

--- a/test/utils/icon_utils_test.exs
+++ b/test/utils/icon_utils_test.exs
@@ -26,9 +26,9 @@ defmodule FindSiteIcon.Util.IconUtilsTest do
   end
 
   test "generate_size/1" do
-    assert IconUtils.generate_size(nil) == 0
+    assert IconUtils.generate_size(nil) == nil
     assert IconUtils.generate_size("") == 0
-    assert IconUtils.generate_size(123) == 0
+    assert IconUtils.generate_size(123) == nil
     assert IconUtils.generate_size("1234") == 1234
   end
 


### PR DESCRIPTION
Some places use base64 encoded images instead of icon urls. This PR ignores the base64 encoded icons for now.

Also, improves the content-length header filtering. If the content-length specifically comes as 0, is it ignored.