### PR TITLE
Only accept png and jpeg files of a certain size and above

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule FindSiteIcon.MixProject do
   use Mix.Project
 
-  @version "0.3.6"
+  @version "0.3.7"
   @url "https://github.com/XukuLLC/find_site_icon"
   @maintainers [
     "Neil Berkman"


### PR DESCRIPTION
DISCLAIMER: This would stop allowing favicons to be accepted as valid icons. That in turn could result in a whole bunch of websites not providing icons anymore because they only provide `.ico` icons. e.g. https://iitraa.almaconnect.com/

We are also going to filter out icons which are too small, as their resolution would not be acceptable.

Thus, after this PR, we'll only get decently sized PNG/JPEG icons for a website, if no such icons are found, we'll have to provide our own, probably via `default_icon_url`.