### PR TITLE
Fix #15: Cap Finch pool idle time and expose pool_max_idle_time option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Set a finite default `pool_max_idle_time` (30 seconds) for the internal Req/Finch HTTP client so idle connections release their file descriptors. Without this, processing large lists of distinct hosts could exhaust the per-process open-file limit and silently truncate results or crash the BEAM. ([#15](https://github.com/XukuLLC/find_site_icon/issues/15))
+
 ## 1.0.1 - 2026-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Set a finite default `pool_max_idle_time` (30 seconds) for the internal Req/Finch HTTP client so idle connections release their file descriptors. Without this, processing large lists of distinct hosts could exhaust the per-process open-file limit and silently truncate results or crash the BEAM. ([#15](https://github.com/XukuLLC/find_site_icon/issues/15))
 
+### Added
+
+- New `:pool_max_idle_time` option on `FindSiteIcon.find_icon/2` so callers can override the default 30-second Finch idle-pool timeout per call. Accepts a positive integer in milliseconds or `:infinity` (which restores Req's pre-1.0.2 behaviour of keeping idle pools alive forever).
+
 ## 1.0.1 - 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ FindSiteIcon.find_icon("https://example.com", timeout: 3_000)
 | `:http_options` | Passes Req options to the internal HTTP client. |
 | `:max_concurrency` | Limits concurrent icon probes. Defaults to `8`. |
 | `:max_icons` | Limits how many candidate icon URLs are probed. Defaults to no limit. |
+| `:pool_max_idle_time` | Milliseconds before idle Finch socket pools are terminated so file descriptors are reclaimed when probing many distinct hosts. Defaults to `30_000`. Pass `:infinity` to restore Req's pre-1.0.2 behaviour of keeping pools alive forever. |
 
 ## What It Checks
 

--- a/lib/find_site_icon.ex
+++ b/lib/find_site_icon.ex
@@ -14,6 +14,7 @@ defmodule FindSiteIcon do
           | {:http_options, keyword}
           | {:max_concurrency, pos_integer}
           | {:max_icons, pos_integer | :infinity}
+          | {:pool_max_idle_time, pos_integer | :infinity}
           | {:timeout, timeout}
 
   @known_icon_locations [
@@ -40,6 +41,9 @@ defmodule FindSiteIcon do
   * :http_options -> passes Req options to the internal HTTP client.
   * :max_concurrency -> limits concurrent icon probes. Defaults to 8.
   * :max_icons -> limits how many candidate icon URLs will be probed. Defaults to no limit.
+  * :pool_max_idle_time -> milliseconds before idle Finch socket pools are terminated so
+  file descriptors are reclaimed when probing many distinct hosts. Defaults to 30_000.
+  Pass `:infinity` to restore Req's pre-1.0.2 behaviour of keeping pools alive forever.
 
   ## Examples
 
@@ -346,8 +350,13 @@ defmodule FindSiteIcon do
   end
 
   defp http_options(opts) do
-    http_options = Keyword.get(opts, :http_options, [])
+    opts
+    |> Keyword.get(:http_options, [])
+    |> apply_timeout(opts)
+    |> apply_pool_max_idle_time(opts)
+  end
 
+  defp apply_timeout(http_options, opts) do
     case Keyword.fetch(opts, :timeout) do
       {:ok, timeout} when is_integer(timeout) and timeout >= 0 ->
         Keyword.put_new(http_options, :timeout, timeout)
@@ -356,6 +365,29 @@ defmodule FindSiteIcon do
         http_options
     end
   end
+
+  # The 30_000 ms default lives in `FindSiteIcon.Util.HTTPUtils.new/1`. We
+  # only forward `:pool_max_idle_time` when the caller passed it explicitly,
+  # so the common case still produces an empty http_options list. That way
+  # the internal `HTMLFetcher.fetch_html/1` arity is used when no other HTTP
+  # opts need to be threaded through.
+  defp apply_pool_max_idle_time(http_options, opts) do
+    case Keyword.fetch(opts, :pool_max_idle_time) do
+      {:ok, value} ->
+        if valid_pool_max_idle_time?(value) do
+          Keyword.put_new(http_options, :pool_max_idle_time, value)
+        else
+          http_options
+        end
+
+      :error ->
+        http_options
+    end
+  end
+
+  defp valid_pool_max_idle_time?(:infinity), do: true
+  defp valid_pool_max_idle_time?(value) when is_integer(value) and value > 0, do: true
+  defp valid_pool_max_idle_time?(_), do: false
 
   defp icon_fetch_timeout(opts) do
     Keyword.get(opts, :timeout, @default_icon_fetch_timeout)

--- a/lib/find_site_icon/utils/http_utils.ex
+++ b/lib/find_site_icon/utils/http_utils.ex
@@ -5,6 +5,9 @@ defmodule FindSiteIcon.Util.HTTPUtils do
 
   @timeout 30_000
   @user_agent "find_site_icon (+https://github.com/XukuLLC/find_site_icon)"
+  # Terminate idle Finch pools after this many milliseconds so file
+  # descriptors are reclaimed when probing many distinct hosts. See issue #15.
+  @pool_max_idle_time 30_000
 
   @spec new(keyword) :: Req.Request.t()
   def new(opts \\ []) when is_list(opts) do
@@ -13,6 +16,7 @@ defmodule FindSiteIcon.Util.HTTPUtils do
     Req.new(
       connect_options: [timeout: @timeout],
       headers: [{"user-agent", @user_agent}],
+      pool_max_idle_time: @pool_max_idle_time,
       receive_timeout: @timeout,
       redirect: true,
       retry: false

--- a/lib/find_site_icon/utils/http_utils.ex
+++ b/lib/find_site_icon/utils/http_utils.ex
@@ -1,12 +1,19 @@
 defmodule FindSiteIcon.Util.HTTPUtils do
   @moduledoc """
   Small wrapper around Req with project defaults.
+
+  Accepts the same options as `Req.new/1`, plus the following defaults that
+  callers may override by passing the key explicitly:
+
+  * `:timeout` -> applied to both connect and receive timeouts. Defaults to 30s.
+  * `:pool_max_idle_time` -> milliseconds before idle Finch socket pools are
+    terminated. Defaults to 30s so file descriptors are reclaimed when probing
+    many distinct hosts. Pass `:infinity` to keep pools alive forever, which
+    was Req's behaviour prior to find_site_icon 1.0.2. See issue #15.
   """
 
   @timeout 30_000
   @user_agent "find_site_icon (+https://github.com/XukuLLC/find_site_icon)"
-  # Terminate idle Finch pools after this many milliseconds so file
-  # descriptors are reclaimed when probing many distinct hosts. See issue #15.
   @pool_max_idle_time 30_000
 
   @spec new(keyword) :: Req.Request.t()

--- a/test/find_site_icon_test.exs
+++ b/test/find_site_icon_test.exs
@@ -59,6 +59,66 @@ defmodule FindSiteIconTest do
     end
   end
 
+  test "pool_max_idle_time can be overridden with an integer" do
+    url = "https://www.nytimes.com"
+    test_pid = self()
+
+    with_mocks([
+      {Cache, [], get: fn _url -> nil end},
+      {HTMLFetcher, [],
+       fetch_html: fn ^url, http_opts ->
+         send(test_pid, {:http_opts, http_opts})
+         {:ok, "<html></html>"}
+       end},
+      {IconUtils, [], icon_info_for: fn _, _ -> nil end}
+    ]) do
+      FindSiteIcon.find_icon(url, pool_max_idle_time: 5_000)
+
+      assert_received {:http_opts, http_opts}
+      assert Keyword.get(http_opts, :pool_max_idle_time) == 5_000
+    end
+  end
+
+  test "pool_max_idle_time accepts :infinity to disable idle-pool eviction" do
+    url = "https://www.nytimes.com"
+    test_pid = self()
+
+    with_mocks([
+      {Cache, [], get: fn _url -> nil end},
+      {HTMLFetcher, [],
+       fetch_html: fn ^url, http_opts ->
+         send(test_pid, {:http_opts, http_opts})
+         {:ok, "<html></html>"}
+       end},
+      {IconUtils, [], icon_info_for: fn _, _ -> nil end}
+    ]) do
+      FindSiteIcon.find_icon(url, pool_max_idle_time: :infinity)
+
+      assert_received {:http_opts, http_opts}
+      assert Keyword.get(http_opts, :pool_max_idle_time) == :infinity
+    end
+  end
+
+  test "an explicit :http_options[:pool_max_idle_time] wins over the top-level option default" do
+    url = "https://www.nytimes.com"
+    test_pid = self()
+
+    with_mocks([
+      {Cache, [], get: fn _url -> nil end},
+      {HTMLFetcher, [],
+       fetch_html: fn ^url, http_opts ->
+         send(test_pid, {:http_opts, http_opts})
+         {:ok, "<html></html>"}
+       end},
+      {IconUtils, [], icon_info_for: fn _, _ -> nil end}
+    ]) do
+      FindSiteIcon.find_icon(url, http_options: [pool_max_idle_time: 1_234])
+
+      assert_received {:http_opts, http_opts}
+      assert Keyword.get(http_opts, :pool_max_idle_time) == 1_234
+    end
+  end
+
   test "probes all candidate icons by default" do
     url = "https://www.nytimes.com"
 

--- a/test/utils/http_utils_test.exs
+++ b/test/utils/http_utils_test.exs
@@ -7,20 +7,25 @@ defmodule FindSiteIcon.Util.HTTPUtilsTest do
   alias FindSiteIcon.IconInfo
   alias FindSiteIcon.Util.{HTTPUtils, IconUtils}
 
-  test "new/1 sets a finite pool_max_idle_time so idle connections release file descriptors" do
+  test "new/1 defaults pool_max_idle_time to 30_000 so idle connections release file descriptors" do
     # Regression test for issue #15: without this option, Req's Finch pools
     # default to :infinity max idle time, so probing many distinct hosts
     # leaks file descriptors until the OS limit is hit.
     request = HTTPUtils.new()
 
-    assert is_integer(request.options[:pool_max_idle_time])
-    assert request.options[:pool_max_idle_time] > 0
+    assert request.options[:pool_max_idle_time] == 30_000
   end
 
-  test "new/1 allows callers to override pool_max_idle_time" do
+  test "new/1 allows callers to override pool_max_idle_time with an integer" do
     request = HTTPUtils.new(pool_max_idle_time: 5_000)
 
     assert request.options[:pool_max_idle_time] == 5_000
+  end
+
+  test "new/1 allows callers to override pool_max_idle_time with :infinity" do
+    request = HTTPUtils.new(pool_max_idle_time: :infinity)
+
+    assert request.options[:pool_max_idle_time] == :infinity
   end
 
   test "do_get/3 follows redirects and returns response body" do

--- a/test/utils/http_utils_test.exs
+++ b/test/utils/http_utils_test.exs
@@ -7,6 +7,22 @@ defmodule FindSiteIcon.Util.HTTPUtilsTest do
   alias FindSiteIcon.IconInfo
   alias FindSiteIcon.Util.{HTTPUtils, IconUtils}
 
+  test "new/1 sets a finite pool_max_idle_time so idle connections release file descriptors" do
+    # Regression test for issue #15: without this option, Req's Finch pools
+    # default to :infinity max idle time, so probing many distinct hosts
+    # leaks file descriptors until the OS limit is hit.
+    request = HTTPUtils.new()
+
+    assert is_integer(request.options[:pool_max_idle_time])
+    assert request.options[:pool_max_idle_time] > 0
+  end
+
+  test "new/1 allows callers to override pool_max_idle_time" do
+    request = HTTPUtils.new(pool_max_idle_time: 5_000)
+
+    assert request.options[:pool_max_idle_time] == 5_000
+  end
+
   test "do_get/3 follows redirects and returns response body" do
     bypass = Bypass.open()
 


### PR DESCRIPTION
## Summary

- Closes #15.
- Sets a finite default `pool_max_idle_time` (30 seconds) for the internal Req/Finch HTTP client so idle connections release their file descriptors.
- Exposes `:pool_max_idle_time` as a first-class option on `FindSiteIcon.find_icon/2` so callers can override the default per call (accepts a positive integer in milliseconds or `:infinity`).
- Adds regression tests at both the `HTTPUtils.new/1` and `FindSiteIcon.find_icon/2` levels.

## Root cause

`Req`'s default Finch pool keeps connections open indefinitely (`pool_max_idle_time: :infinity`) and allocates up to 50 sockets per `{scheme, host, port}`. When callers probe many distinct hosts in one process, for example looping `FindSiteIcon.find_icon/1` over hundreds of domains as the reporter's script does, the accumulated idle sockets exhaust the process file descriptor limit. macOS' default per-process limit is 256, which matches the reporter's observation that they get roughly 70 successful results without raising `ulimit -n` but consistently get the full ~750 with `ulimit -n 65536`. The BEAM-can-no-longer-open-its-own-files crashes are consistent with the same root cause.

## Fix

`FindSiteIcon.Util.HTTPUtils.new/1` now passes `pool_max_idle_time: 30_000` to `Req.new/1` by default. Idle Finch pools (and the sockets they hold) get terminated 30 seconds after the last request to a given host, so file descriptors are reclaimed steadily as the caller walks down a long list of domains.

## New `:pool_max_idle_time` option

`FindSiteIcon.find_icon/2` now accepts `:pool_max_idle_time` directly so callers don't have to know the underlying Req key or thread it through `:http_options`:

```elixir
# Use the default 30s eviction
FindSiteIcon.find_icon("https://example.com")

# Tighten it for very long host lists on a low FD limit
FindSiteIcon.find_icon("https://example.com", pool_max_idle_time: 5_000)

# Restore Req's pre-1.0.2 behaviour of keeping pools alive forever
FindSiteIcon.find_icon("https://example.com", pool_max_idle_time: :infinity)
```

The new option is documented in the `@doc` for `find_icon/2`, the README options table, and `CHANGELOG.md`. An explicit `:pool_max_idle_time` inside `:http_options` still wins, so existing callers that already set it that way keep working unchanged.

## Test plan

- `mix test` (44 tests pass)
- `mix precommit` (format, compile --warnings-as-errors, credo --strict, test) all clean
- Tests in `test/utils/http_utils_test.exs` confirm the default, an integer override, and an `:infinity` override at the HTTP wrapper level.
- Tests in `test/find_site_icon_test.exs` confirm the new public option flows through to the HTTP layer for both integer and `:infinity` values, and that an inner `:http_options[:pool_max_idle_time]` wins.