### PR TITLE
Declare Elixir 1.20 package support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Enabled Req response decompression by default so compressed pages and icons continue to be decoded correctly with Req 0.6+. ([#17](https://github.com/XukuLLC/find_site_icon/issues/17))
+- Declared Elixir 1.20 support in package metadata after adding it to CI.
 
 ## 1.0.2 - 2026-05-18
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule FindSiteIcon.MixProject do
       name: "FindSiteIcon",
       app: :find_site_icon,
       version: @version,
-      elixir: "~> 1.17 or ~> 1.18 or ~> 1.19",
+      elixir: "~> 1.17 or ~> 1.18 or ~> 1.19 or ~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       source_url: @url,


### PR DESCRIPTION
## Summary

- Include Elixir 1.20 in the package metadata now that CI covers Elixir 1.20 / OTP 29.
- Note the metadata support in the 1.0.3 changelog entry.

## Validation

- `ERL_COMPILER_OPTIONS=nowarn_deprecated_catch mix precommit`
- `ERL_COMPILER_OPTIONS=nowarn_deprecated_catch mix dialyzer`
- `mix hex.build`
